### PR TITLE
add: add columns, change columns info, fix joins, and more

### DIFF
--- a/models/planejamento_gestao_dashboard_metas/pe_detalhes.sql
+++ b/models/planejamento_gestao_dashboard_metas/pe_detalhes.sql
@@ -386,5 +386,13 @@ SELECT
   "Cumprida parcialmente" AS tendencia_pe
 )
 
-SELECT * FROM pe_detalhes_final
+SELECT 
+  *, 
+  CONCAT(
+    "Meta para 2021: ", _2021, "\n",
+    "Meta para 2022: ", _2022, "\n",
+    "Meta para 2023: ", _2023, "\n",
+    "Meta para 2024: ", _2024
+  ) pe_desdobramento_anual_da_meta
+FROM pe_detalhes_final
 ORDER BY origem, orgao_responsavel, codigo_meta

--- a/models/planejamento_gestao_dashboard_metas/todos_detalhes.sql
+++ b/models/planejamento_gestao_dashboard_metas/todos_detalhes.sql
@@ -38,13 +38,14 @@ SELECT
   ped._2022 as pe_objetivo_2022,
   ped.ultimo_resultado as pe_ultimo_resultado,
   ped.data_referencia_resultado as pe_data_referencia_ultimo_resultado,
-  ped.indicador_dashboard_prefeito as pe_nome_meta,
+  ped.descricao_meta_desdobrada as pe_nome_meta,
   ped.cor_fonte as pe_cor_fonte,
   ped.pe_tendencia_normalizada as pe_tendencia_meta_desdobrada,
   ped.tema_transversal as pe_tema_transversal,
   ped.meta as pe_descricao_meta,
   ped.comentarios_da_meta as pe_comentarios_da_meta,
   ped.resumo_executivo as pe_resumo_executivo,
+  ped.pe_desdobramento_anual_da_meta,
 FROM {{ ref('ar_detalhes') }} as ard
 LEFT JOIN (
   SELECT 
@@ -74,13 +75,14 @@ ORDER BY pe_tipo_meta DESC
     ped._2022 as pe_objetivo_2022,
     ped.ultimo_resultado as pe_ultimo_resultado,
     ped.data_referencia_resultado as pe_data_referencia_ultimo_resultado,
-    ped.indicador_dashboard_prefeito as pe_nome_meta,
+    ped.descricao_meta_desdobrada as pe_nome_meta,
     ped.cor_fonte as pe_cor_fonte,
     ped.pe_tendencia_normalizada as pe_tendencia_meta_desdobrada,
     ped.meta as pe_descricao_meta,
     ped.tema_transversal as pe_tema_transversal,
     ped.comentarios_da_meta as pe_comentarios_da_meta,
     ped.resumo_executivo as pe_resumo_executivo,
+    ped.pe_desdobramento_anual_da_meta,
     ard.id_meta_mae,
     ard.pior_tendencia_meta_mae,
     ard.ar_data_referencia_ultimo_resultado,
@@ -169,7 +171,8 @@ SELECT
   ar_resumo_comentarios               as dashboard_comentarios,
   "ACORDO DE RESULTADOS"              as dashboard_tema,
   ar_objetivo_2022                    as dashboard_detalhamento_objetivo,
-  ar_tipo_meta                        as tipo_meta
+  ar_tipo_meta                        as tipo_meta,
+  NULL                                as desdobramento_anual_da_meta,
 FROM ar_com_pe
 
 UNION ALL 
@@ -228,7 +231,8 @@ SELECT
   pe_comentarios_da_meta              as dashboard_comentarios,
   pe_tema_transversal                 as dashboard_tema,
   pe_objetivo_2022                    as dashboard_detalhamento_objetivo,
-  pe_tipo_meta                        as tipo_meta
+  pe_tipo_meta                        as tipo_meta,
+  pe_desdobramento_anual_da_meta      as desdobramento_anual_da_meta,
 FROM pe_com_ar
 )
 
@@ -289,6 +293,7 @@ SELECT
   dashboard_tema,
   dashboard_detalhamento_objetivo,
   tipo_meta,
+  desdobramento_anual_da_meta,
   (ROW_NUMBER() OVER (ORDER BY 
     ordenacao_orgaos, 
     ordenacao_origem, 


### PR DESCRIPTION
Fiz as seguintes modificações:

•	Meta Performance da SMI que tem status “Andamento Satisfatório” em Setembro, aparece no Dashboard com status “Não se aplica/Sem Informações”. A data do último resultado (tela metas) que aparece no Dashboard também está estranha: 03/11/2022. E isso está ocorrendo com outros órgãos também.
Isso pode estar acontecendo porque o EGPWEB tem meses separados para os três tipos de informação que aparecem no Dashboard: indicador, chance e comentários. Os dados mais atuais de cada tipo de informação devem ser trazidos, desde que sejam menores ou iguais ao mês atual.
•	Na tela Detalhe das Metas, quando for uma meta do AR, o ideal é que o Resumo Executivo seja carregado com os comentários mais atuais. Muitas vezes os resultados não são informados pelo órgão e ficam com o mês desatualizado, mais antigo, mas os analistas colocam comentários e chances mensalmente. Por isso deveria pegar os comentários mais atuais desde que o mês seja menor ou igual ao atual. O mesmo serve para a chance, conforme solicitado no item anterior.
•	Tela Metas: Coluna Descrição quando Origem = “PE” ou “PE/AR”: a coluna é a Descrição Meta Desdobrada (DI) no lugar da Indicador (DJ) para padronizar com o AR. (Essa solicitação está no e-mail de 27/06, no sexto bullet.)
Coluna Descrição quando Origem = “AR”: De onde está pegando essa informação? Da tabela metas do dataset planejamento_gestao_acordo_resultados ou do Google Sheets Base_Metas_AR. Se for desse segundo, favor pegar a coluna “Descrição Meta AR 2022 Desdobrada” (coluna H no lugar da coluna G).
•	Tela de Detalhamento: Mostrar o desdobramento anual da meta (2021, 2022, 2023, 2024) se ela for do plano estratégico. Pode ser quando passar o mouse sobre o quadro Meta para 2022, como já tínhamos conversado.
