### PR TITLE
DBT: Atualização do Dashboard de metas para avaliar as metas para 202…

### DIFF
--- a/models/planejamento_gestao_dashboard_metas/ar_detalhes.sql
+++ b/models/planejamento_gestao_dashboard_metas/ar_detalhes.sql
@@ -150,9 +150,9 @@ with chance_com_comentario as (
   meta.novembro,
   meta.dezembro
   FROM `rj-smfp.planejamento_gestao_acordo_resultados.meta` as meta
-  LEFT JOIN (SELECT * FROM `rj-smfp.planejamento_gestao_acordo_resultados_staging.meta_desdobrada` WHERE ano = '2023') as arp
+  LEFT JOIN (SELECT * FROM `rj-smfp.planejamento_gestao_acordo_resultados_staging.meta_desdobrada` WHERE ano = '2024') as arp
     ON meta.id_meta = CAST(CAST(arp.codigo_egpweb AS FLOAT64) AS STRING)
-  WHERE meta.ano = 2023
+  WHERE meta.ano = 2024
 )
 
 , info_tendencia as (

--- a/models/planejamento_gestao_dashboard_metas/pe_detalhes.sql
+++ b/models/planejamento_gestao_dashboard_metas/pe_detalhes.sql
@@ -147,22 +147,22 @@ SELECT
   origem,
   --tendencia_subdivisao,
   CASE 
-    WHEN LOWER(tendencia_cumprimento_meta_2023) = "tendência de cumprir" or              LOWER(tendencia_cumprimento_meta_2023) = "cumprida" then "#005A38" 
-    WHEN LOWER(tendencia_cumprimento_meta_2023) = "tendência de cumprir parcialmente" or LOWER(tendencia_cumprimento_meta_2023) = "cumprida parcialmente" then "#ABAD67" 
-    WHEN LOWER(tendencia_cumprimento_meta_2023) = "tendência de não cumprir" or          LOWER(tendencia_cumprimento_meta_2023) = "não cumprida" then "#DE9B89" 
-    WHEN LOWER(tendencia_cumprimento_meta_2023) = "descontinuada" then "#8B0000"
+    WHEN LOWER(tendencia_cumprimento_meta_2024) = "tendência de cumprir" or              LOWER(tendencia_cumprimento_meta_2024) = "cumprida" then "#005A38" 
+    WHEN LOWER(tendencia_cumprimento_meta_2024) = "tendência de cumprir parcialmente" or LOWER(tendencia_cumprimento_meta_2024) = "cumprida parcialmente" then "#ABAD67" 
+    WHEN LOWER(tendencia_cumprimento_meta_2024) = "tendência de não cumprir" or          LOWER(tendencia_cumprimento_meta_2024) = "não cumprida" then "#DE9B89" 
+    WHEN LOWER(tendencia_cumprimento_meta_2024) = "descontinuada" then "#8B0000"
     ELSE "#4F4F4F" END 
     AS cor_fonte,
   CASE 
-    WHEN LOWER(tendencia_cumprimento_meta_2023) = "cumprida" then "Cumprida"
-    WHEN LOWER(tendencia_cumprimento_meta_2023) = "cumprida parcialmente" then "Cumprida parcialmente"
-    WHEN LOWER(tendencia_cumprimento_meta_2023) = "não cumprida" then "Não cumprida"
-    WHEN LOWER(tendencia_cumprimento_meta_2023) = "tendência de cumprir" then "Andamento Satisfatório"
-    WHEN LOWER(tendencia_cumprimento_meta_2023) = "tendência de cumprir parcialmente" then "Atraso Recuperável"
-    WHEN LOWER(tendencia_cumprimento_meta_2023) = "tendência de não cumprir" then "Atraso grave"
-    WHEN LOWER(tendencia_cumprimento_meta_2023) = "indefinida" then "Indefinida"
-    WHEN LOWER(tendencia_cumprimento_meta_2023) = "não se aplica" then "Sem informações/Não se aplica" 
-    WHEN LOWER(tendencia_cumprimento_meta_2023) = "descontinuada" then "Descontinuada" 
+    WHEN LOWER(tendencia_cumprimento_meta_2024) = "cumprida" then "Cumprida"
+    WHEN LOWER(tendencia_cumprimento_meta_2024) = "cumprida parcialmente" then "Cumprida parcialmente"
+    WHEN LOWER(tendencia_cumprimento_meta_2024) = "não cumprida" then "Não cumprida"
+    WHEN LOWER(tendencia_cumprimento_meta_2024) = "tendência de cumprir" then "Andamento Satisfatório"
+    WHEN LOWER(tendencia_cumprimento_meta_2024) = "tendência de cumprir parcialmente" then "Atraso Recuperável"
+    WHEN LOWER(tendencia_cumprimento_meta_2024) = "tendência de não cumprir" then "Atraso grave"
+    WHEN LOWER(tendencia_cumprimento_meta_2024) = "indefinida" then "Indefinida"
+    WHEN LOWER(tendencia_cumprimento_meta_2024) = "não se aplica" then "Sem informações/Não se aplica" 
+    WHEN LOWER(tendencia_cumprimento_meta_2024) = "descontinuada" then "Descontinuada" 
     ELSE "VALOR NÃO ENCONTRADO" END
     AS pe_tendencia_normalizada,
   codigo_tema,
@@ -186,7 +186,7 @@ SELECT
     ELSE _2021
   END _2021,
   CASE 
-    WHEN CONTAINS_SUBSTR(_2021, "Sem valor alvo") AND _2022 != "Sem valor alvo" THEN REPLACE(_2022, "Sem valor alvo", "")
+    WHEN CONTAINS_SUBSTR(_2022, "Sem valor alvo") AND _2022 != "Sem valor alvo" THEN REPLACE(_2022, "Sem valor alvo", "")
     ELSE _2022
   END _2022,
   CASE 
@@ -194,7 +194,7 @@ SELECT
     ELSE _2023
   END _2023,
   CASE 
-    WHEN CONTAINS_SUBSTR(_2021, "Sem valor alvo") AND _2024 != "Sem valor alvo" THEN REPLACE(_2024, "Sem valor alvo", "")
+    WHEN CONTAINS_SUBSTR(_2024, "Sem valor alvo") AND _2024 != "Sem valor alvo" THEN REPLACE(_2024, "Sem valor alvo", "")
     ELSE _2024
   END _2024,
   CASE 
@@ -269,15 +269,15 @@ SELECT
   --orgao_responsavel,
   codigo_meta,                                
   MIN(CASE
-    WHEN LOWER(tendencia_cumprimento_meta_2023) = "não cumprida" then 0
-    WHEN LOWER(tendencia_cumprimento_meta_2023) = "descontinuada" then 1
-    WHEN LOWER(tendencia_cumprimento_meta_2023) = "indefinida" then 2
-    WHEN LOWER(tendencia_cumprimento_meta_2023) = "tendência de não cumprir" then 3
-    WHEN LOWER(tendencia_cumprimento_meta_2023) = "cumprida parcialmente" then 4
-    WHEN LOWER(tendencia_cumprimento_meta_2023) = "tendência de cumprir parcialmente" then 5    
-    WHEN LOWER(tendencia_cumprimento_meta_2023) = "tendência de cumprir" then 6
-    WHEN LOWER(tendencia_cumprimento_meta_2023) = "não se aplica" or LOWER(tendencia_cumprimento_meta_2023) = "não" then 7
-    WHEN LOWER(tendencia_cumprimento_meta_2023) = "cumprida" then 8
+    WHEN LOWER(tendencia_cumprimento_meta_2024) = "não cumprida" then 0
+    WHEN LOWER(tendencia_cumprimento_meta_2024) = "descontinuada" then 1
+    WHEN LOWER(tendencia_cumprimento_meta_2024) = "indefinida" then 2
+    WHEN LOWER(tendencia_cumprimento_meta_2024) = "tendência de não cumprir" then 3
+    WHEN LOWER(tendencia_cumprimento_meta_2024) = "cumprida parcialmente" then 4
+    WHEN LOWER(tendencia_cumprimento_meta_2024) = "tendência de cumprir parcialmente" then 5    
+    WHEN LOWER(tendencia_cumprimento_meta_2024) = "tendência de cumprir" then 6
+    WHEN LOWER(tendencia_cumprimento_meta_2024) = "não se aplica" or LOWER(tendencia_cumprimento_meta_2024) = "não" then 7
+    WHEN LOWER(tendencia_cumprimento_meta_2024) = "cumprida" then 8
 
     ELSE 999 END) tendencia_numero_pe,
 FROM pe_geral

--- a/models/planejamento_gestao_dashboard_metas/pe_numerico.sql
+++ b/models/planejamento_gestao_dashboard_metas/pe_numerico.sql
@@ -144,7 +144,7 @@ pe_valores as (
 SELECT
   id_meta_secretaria,
   origem,
-  tendencia_cumprimento_meta_2023,
+  tendencia_cumprimento_meta_2024,
   -- tendencia_subdivisao,
   tipo_meta,
   casas_decimais,
@@ -219,7 +219,7 @@ pe_numerico as (
   SELECT
     id_meta_secretaria,
     origem,
-    tendencia_cumprimento_meta_2023,
+    tendencia_cumprimento_meta_2024,
     -- tendencia_subdivisao,
     tipo_meta,
     casas_decimais,

--- a/models/planejamento_gestao_dashboard_metas/pe_porcentagem.sql
+++ b/models/planejamento_gestao_dashboard_metas/pe_porcentagem.sql
@@ -144,7 +144,7 @@ pe_valores as (
 SELECT
   id_meta_secretaria,
   origem,
-  tendencia_cumprimento_meta_2023,
+  tendencia_cumprimento_meta_2024,
   -- tendencia_subdivisao,
   tipo_meta,
   casas_decimais,
@@ -219,7 +219,7 @@ pe_porcentagem as (
   SELECT
     id_meta_secretaria,
     origem,
-    tendencia_cumprimento_meta_2023,
+    tendencia_cumprimento_meta_2024,
     -- tendencia_subdivisao,
     tipo_meta,
     casas_decimais,

--- a/models/planejamento_gestao_dashboard_metas/pe_ranking.sql
+++ b/models/planejamento_gestao_dashboard_metas/pe_ranking.sql
@@ -143,7 +143,7 @@ pe_valores as (
 SELECT
   id_meta_secretaria,
   origem,
-  tendencia_cumprimento_meta_2023,
+  tendencia_cumprimento_meta_2024,
   -- tendencia_subdivisao,
   tipo_meta,
   casas_decimais,
@@ -218,7 +218,7 @@ pe_ranking as (
   SELECT
     id_meta_secretaria,
     origem,
-    tendencia_cumprimento_meta_2023,
+    tendencia_cumprimento_meta_2024,
     -- tendencia_subdivisao,
     tipo_meta,
     casas_decimais,

--- a/models/planejamento_gestao_dashboard_metas/pe_textual.sql
+++ b/models/planejamento_gestao_dashboard_metas/pe_textual.sql
@@ -143,7 +143,7 @@ pe_valores as (
 SELECT
   id_meta_secretaria,
   origem,
-  tendencia_cumprimento_meta_2023,
+  tendencia_cumprimento_meta_2024,
   -- tendencia_subdivisao,
   tipo_meta,
   casas_decimais,
@@ -218,7 +218,7 @@ pe_textual as (
   SELECT
     id_meta_secretaria,
     origem,
-    tendencia_cumprimento_meta_2023,
+    tendencia_cumprimento_meta_2024,
     -- tendencia_subdivisao,
     tipo_meta,
     casas_decimais,

--- a/models/planejamento_gestao_dashboard_metas/todos_detalhes.sql
+++ b/models/planejamento_gestao_dashboard_metas/todos_detalhes.sql
@@ -26,7 +26,7 @@ SELECT
     WHEN ar_unidade_medida = "Percentual" THEN REPLACE(CONCAT(FORMAT("%'d", CAST(FLOOR(dezembro) AS int64)), SUBSTR(FORMAT("%.2f", CAST(dezembro AS float64)), -3), "%"), ".", ",")
     WHEN ar_unidade_medida = "Textual" THEN "Meta entregue"
     ELSE SAFE_CAST(dezembro AS STRING)
-  END as ar_objetivo_2023,
+  END as ar_objetivo_2024,
   ped.id_meta_secretaria as pe_id_meta_secretaria,
   ped.codigo_meta,
   ped.tendencia_pe,
@@ -34,8 +34,8 @@ SELECT
   ped.orgao_responsavel as pe_orgao,
   ped.tipo_meta as pe_tipo_meta,
   ped.casas_decimais as pe_casas_decimais,
-  ped.valor_meta_final AS pe_objetivo_2024,
-  ped._2023 as pe_objetivo_2023,
+  ped.valor_meta_final AS pe_objetivo_final_2024,
+  ped._2024 as pe_objetivo_anual_2024,
   ped.ultimo_resultado as pe_ultimo_resultado,
   ped.data_referencia_resultado as pe_data_referencia_ultimo_resultado,
   ped.descricao_meta_desdobrada as pe_nome_meta,
@@ -55,7 +55,7 @@ LEFT JOIN (
     MIN(chave_meta_ar_egpweb) chave_meta_ar_egpweb
   FROM `rj-smfp.planejamento_gestao_dashboard_metas_staging.relacao_metas` 
   WHERE relacao_entre_indicadores = '1 - Direta (Mesmo indicador)'
-  AND   chave_meta_ar like '2023%'
+  AND   chave_meta_ar like '2024%'
   GROUP BY chave_meta_pe
   ) as rm
   ON ard.id_meta = rm.chave_meta_ar_egpweb
@@ -75,8 +75,8 @@ ORDER BY pe_tipo_meta DESC
     ped.orgao_responsavel as pe_orgao,
     ped.tipo_meta as pe_tipo_meta,
     ped.casas_decimais as pe_casas_decimais,
-    ped.valor_meta_final AS pe_objetivo_2024,
-    ped._2023 as pe_objetivo_2023,
+    ped.valor_meta_final AS pe_objetivo_final_2024,
+    ped._2024 as pe_objetivo_anual_2024,
     ped.ultimo_resultado as pe_ultimo_resultado,
     ped.data_referencia_resultado as pe_data_referencia_ultimo_resultado,
     ped.descricao_meta_desdobrada as pe_nome_meta,
@@ -109,7 +109,7 @@ ORDER BY pe_tipo_meta DESC
       WHEN ar_unidade_medida = "Percentual" THEN REPLACE(CONCAT(FORMAT("%'d", CAST(FLOOR(dezembro) AS int64)), SUBSTR(FORMAT("%.2f", CAST(dezembro AS float64)), -3), "%"), ".", ",")
       WHEN ar_unidade_medida = "Textual" THEN "Meta entregue"
       ELSE SAFE_CAST(dezembro AS STRING)
-      END as ar_objetivo_2023
+      END as ar_objetivo_2024
   FROM {{ ref('pe_detalhes') }} as ped
   --FROM rj-smfp.planejamento_gestao_dashboard_metas.pe_detalhes as ped
   LEFT JOIN (
@@ -118,7 +118,7 @@ ORDER BY pe_tipo_meta DESC
     MIN(chave_meta_ar_egpweb) chave_meta_ar_egpweb
   FROM `rj-smfp.planejamento_gestao_dashboard_metas_staging.relacao_metas` 
   WHERE relacao_entre_indicadores = '1 - Direta (Mesmo indicador)'
-  AND   chave_meta_ar like '2023%'
+  AND   chave_meta_ar like '2024%'
   GROUP BY chave_meta_pe
   ) as rm
   ON rm.chave_meta_pe = ped.codigo_meta_desdobrada
@@ -136,8 +136,8 @@ SELECT
   ar_origem                           as origem_meta,
   ar_orgao                            as orgao_sigla,
   ar_nome_meta                        as dashboard_nome,
-  pe_objetivo_2023                    as dashboard_objetivo_pe,
-  ar_objetivo_2023                    as dashboard_objetivo_ar,
+  pe_objetivo_anual_2024              as dashboard_objetivo_pe,
+  ar_objetivo_2024                    as dashboard_objetivo_ar,
   CASE
     WHEN ar_data_referencia_ultimo_resultado IS NULL and pe_data_referencia_ultimo_resultado IS NULL THEN NULL
     WHEN ar_data_referencia_ultimo_resultado IS NULL THEN pe_ultimo_resultado
@@ -179,7 +179,7 @@ SELECT
   ar_resumo_comentarios               as dashboard_resumo,
   ar_resumo_comentarios               as dashboard_comentarios,
   "ACORDO DE RESULTADOS"              as dashboard_tema,
-  ar_objetivo_2023                    as dashboard_detalhamento_objetivo,
+  ar_objetivo_2024                    as dashboard_detalhamento_objetivo,
   ar_tipo_meta                        as tipo_meta,
   NULL                                as desdobramento_anual_da_meta,
   pe_codigo_meta_desdobrada           as pe_codigo_meta_desdobrada
@@ -195,8 +195,8 @@ SELECT
   pe_origem                           as origem_meta,
   pe_orgao                            as orgao_sigla,
   pe_nome_meta                        as dashboard_nome,
-  pe_objetivo_2023                    as dashboard_objetivo_pe,
-  ar_objetivo_2023                    as dashboard_objetivo_ar,
+  pe_objetivo_anual_2024              as dashboard_objetivo_pe,
+  ar_objetivo_2024                    as dashboard_objetivo_ar,
   CASE
     WHEN ar_data_referencia_ultimo_resultado IS NULL and pe_data_referencia_ultimo_resultado IS NULL THEN NULL
     WHEN ar_data_referencia_ultimo_resultado IS NULL THEN pe_ultimo_resultado
@@ -241,7 +241,7 @@ SELECT
   pe_resumo_executivo                 as dashboard_resumo,
   pe_comentarios_da_meta              as dashboard_comentarios,
   pe_tema_transversal                 as dashboard_tema,
-  pe_objetivo_2023                    as dashboard_detalhamento_objetivo,
+  pe_objetivo_anual_2024              as dashboard_detalhamento_objetivo,
   pe_tipo_meta                        as tipo_meta,
   pe_desdobramento_anual_da_meta      as desdobramento_anual_da_meta,
   pe_codigo_meta_desdobrada           as pe_codigo_meta_desdobrada
@@ -286,7 +286,7 @@ LEFT JOIN (SELECT
       ELSE FALSE
     END as colocar_logo_abaixo
   FROM `rj-smfp.planejamento_gestao_dashboard_metas_staging.relacao_metas`
-  WHERE chave_meta_ar like '2023%') as rel_ind
+  WHERE chave_meta_ar like '2024%') as rel_ind
     ON tj.id_meta_principal = rel_ind.chave_meta_ar_egpweb
 LEFT JOIN (SELECT codigo_egpweb, MIN(cod_meta_d) as ordem_meta_ar FROM `rj-smfp.planejamento_gestao_acordo_resultados_staging.meta_desdobrada` group by codigo_egpweb) as rm
     ON tj.id_meta_principal = SAFE_CAST(SAFE_CAST(rm.codigo_egpweb AS FLOAT64) AS STRING)


### PR DESCRIPTION
…4 no lugar das metas de 2023, tanto no PE quanto no AR.

O dashboard de metas do Prefeito avalia as metas do ano tanto no Plano Estratégico como no Acordo de Resultados. Após a assinatura dos contratos acordos de 2024 e do iníciodo monitoramento dos mesmos no EGPWeb, foi preciso atualizar as queries que geram as tabelas usadas no dashboard para lerem informações do ano de 2024 no lugar de 2023.